### PR TITLE
Unifies menu structure across all documentation sites

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,9 +1,4 @@
-* xref:user:ROOT:index.adoc[User Docs]
-* xref:portal:ROOT:index.adoc[Portal Docs]
-* xref:appcat:ROOT:index.adoc[AppCat Docs]
-* xref:user:ROOT:contact.adoc[Contact]
-* https://status.appuio.cloud[Status 🔗^]
-* https://portal.appuio.cloud[Portal 🔗^]
+include::user:ROOT:partial$shared-nav.adoc[]
 
 .Object Storage Buckets
 * xref:object-storage/how-to.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
 * xref:index.adoc[]
-* xref:user:ROOT:index.adoc[APPUiO Cloud User Documentation 🔗^]
+* xref:user:ROOT:index.adoc[APPUiO Cloud User Docs 🔗^]
 * xref:portal:ROOT:index.adoc[APPUiO Cloud Portal 🔗^]
 
 .Object Storage Buckets

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,8 @@
-* xref:index.adoc[]
-* xref:user:ROOT:index.adoc[APPUiO Cloud User Docs 🔗^]
-* xref:portal:ROOT:index.adoc[APPUiO Cloud Portal 🔗^]
+* xref:user:ROOT:contact.adoc[Contact]
+* https://status.appuio.cloud[Status 🔗^]
+* https://portal.appuio.cloud[Portal 🔗^]
+* xref:user:ROOT:index.adoc[User Docs 🔗^]
+* xref:portal:ROOT:index.adoc[Portal Docs 🔗^]
 
 .Object Storage Buckets
 * xref:object-storage/how-to.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,8 +1,8 @@
 * xref:user:ROOT:contact.adoc[Contact]
 * https://status.appuio.cloud[Status 🔗^]
 * https://portal.appuio.cloud[Portal 🔗^]
-* xref:user:ROOT:index.adoc[User Docs 🔗^]
-* xref:portal:ROOT:index.adoc[Portal Docs 🔗^]
+* xref:user:ROOT:index.adoc[User Docs]
+* xref:portal:ROOT:index.adoc[Portal Docs]
 
 .Object Storage Buckets
 * xref:object-storage/how-to.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,8 +1,9 @@
+* xref:user:ROOT:index.adoc[User Docs]
+* xref:portal:ROOT:index.adoc[Portal Docs]
+* xref:appcat:ROOT:index.adoc[AppCat Docs]
 * xref:user:ROOT:contact.adoc[Contact]
 * https://status.appuio.cloud[Status 🔗^]
 * https://portal.appuio.cloud[Portal 🔗^]
-* xref:user:ROOT:index.adoc[User Docs]
-* xref:portal:ROOT:index.adoc[Portal Docs]
 
 .Object Storage Buckets
 * xref:object-storage/how-to.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,6 @@
 * xref:index.adoc[]
+* xref:user:ROOT:index.adoc[APPUiO Cloud User Documentation 🔗^]
+* xref:portal:ROOT:index.adoc[APPUiO Cloud Portal 🔗^]
 
 .Object Storage Buckets
 * xref:object-storage/how-to.adoc[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,4 @@
 = VSHN Application Catalog Documentation
-:navtitle: Home
 
 image::appuio-cloud.svg[APPUiO Cloud,400,link=https://www.appuio.ch/en/offering/cloud/]
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,11 +1,11 @@
-= AppCat Documentation
+= VSHN Application Catalog Documentation
 :navtitle: Home
+
+image::appuio-cloud.svg[APPUiO Cloud,400,link=https://www.appuio.ch/en/offering/cloud/]
 
 Welcome to the AppCat Documentation! AppCat allows DevOps engineers to quickly and safely provision cloud services.
 
 IMPORTANT: At this time AppCat only serves selected https://portal.appuio.cloud/zones[APPUiO Cloud zones]. Please check the availability of your desired feature in the corresponding documentation page.
-
-image::appuio-cloud.svg[width=400]
 
 == Available Services
 


### PR DESCRIPTION
Unifies menu structure across all APPUiO Cloud Antora documentation websites using a shared `include` stored in the main documentation (APPUiO Cloud for Users).