### PR TITLE
Dedicated secrets references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,10 @@ clone-crds:
 .PHONY: docs-generate-api
 docs-generate-api: $(crd_ref_docs_bin) ## Generates API reference documentation
 docs-generate-api: clone-crds
-	$(crd_ref_docs_bin) --source-path=.work/crds/apis --config=generator/api-gen-config.yaml --renderer=asciidoctor --templates-dir=generator/api-templates --output-path=docs/modules/ROOT/pages/references/crds.adoc
+	$(crd_ref_docs_bin) --source-path=.work/crds/apis/v1 --config=generator/api-gen-config.yaml --renderer=asciidoctor --templates-dir=generator/api-templates --output-path=docs/modules/ROOT/pages/references/crds.adoc
+	$(crd_ref_docs_bin) --source-path=.work/crds/apis/exoscale/v1 --config=generator/api-gen-config.yaml --renderer=asciidoctor --templates-dir=generator/api-templates --output-path=docs/modules/ROOT/pages/references/crds_exo.adoc
+	$(crd_ref_docs_bin) --source-path=.work/crds/apis/vshn/v1 --config=generator/api-gen-config.yaml --renderer=asciidoctor --templates-dir=generator/api-templates --output-path=docs/modules/ROOT/pages/references/crds_vshn.adoc
+	# a bit hacky, but the tool doesn't support multiple api groups with one call...
+	cat docs/modules/ROOT/pages/references/crds_exo.adoc | sed "s/= API Reference/== Exoscale Reference/g" >> docs/modules/ROOT/pages/references/crds.adoc
+	cat docs/modules/ROOT/pages/references/crds_vshn.adoc | sed "s/= API Reference/== VSHN Reference/g" >> docs/modules/ROOT/pages/references/crds.adoc
+	rm docs/modules/ROOT/pages/references/crds_*.adoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -34,6 +34,7 @@ include::user:ROOT:partial$shared-nav.adoc[]
 ** xref:vshn-managed/postgresql/delete.adoc[]
 ** xref:vshn-managed/postgresql/usage.adoc[]
 
-.Cloud References
+.References
 * xref:references/clouds.adoc[]
 * xref:references/crds.adoc[]
+* xref:references/secrets.adoc[]

--- a/docs/modules/ROOT/pages/exoscale-dbaas/kafka/create.adoc
+++ b/docs/modules/ROOT/pages/exoscale-dbaas/kafka/create.adoc
@@ -60,27 +60,4 @@ $ oc get secrets kafka-creds -o yaml
 
 The output of the command above is a secret specification with the following structure:
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kafka-creds
-data:
-  KAFKA_HOST: bXkta2Fma2EtZXhhbXBsZS04NGc3bi1leG9zY2FsZS04ZjExOTc2OC0xMDI3LTRiOWMtYmNhNy00YzE0ZjlmLmFpdmVuY2xvdWQuY29t <1>
-  KAFKA_NODES: MTk0LjE4Mi4xODkuMTI0OjIxNzAxIDE5NC4xODIuMTg4LjEwOToyMTcwMSAxOTQuMTgyLjE5MC4xNzc6MjE3MDE= <2>
-  KAFKA_PORT: MjE3MDE= <3>
-  KAFKA_URI: bXkta2Fma2EtZXhhbXBsZS04NGc3bi1leG9zY2FsZS04ZjExOTc2OC0xMDI3LTRiOWMtYmNhNy00YzE0ZjlmLmFpdmVuY2xvdWQuY29tOjIxNzAx <4>
-  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVRVENDQXFtZ0F... <5>
-  service.cert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVTRENDQ... <6>
-  service.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUcvQUlCQU... <7>
-----
-<1> Hostname for the Kafka instance
-<2> List of Kafka Node IPs
-<3> Port the Kafka instance listens on
-<4> Full URI including port number
-<5> Certificate Authority to verify the Kafka instance certificate
-<6> Client certificate to authenticate to the instance
-<6> Client key to authenticate to the instance
-
-IMPORTANT: All data fields are Base64-encoded, like any other https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/[Kubernetes secret].
+include::appcat:ROOT:page$references/secrets.adoc[tag=kafka]

--- a/docs/modules/ROOT/pages/exoscale-dbaas/mysql/create.adoc
+++ b/docs/modules/ROOT/pages/exoscale-dbaas/mysql/create.adoc
@@ -61,27 +61,4 @@ $ oc get secrets mysql-creds -o yaml
 
 The output of the command above is a secret specification with the following structure:
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysql-creds
-data:
-  MYSQL_DB: ZGVmYXVsdGRi <1>
-  MYSQL_HOST: bXktbXlzcWwtZXhhbXBsZS1leG9zY2FsZS0xMjM0LmFpdmVuY2xvdWQuY29tCg== <2>
-  MYSQL_PASSWORD: QVZOU19zb21lc3VwZXJzZWNyZXRwdwo= <3>
-  MYSQL_PORT: MjE2OTk= <4>
-  MYSQL_URL: bXlzcWw6Ly9hdm5hZG1pbjpBVk5TX3NvbWVzdXBlcnNlY3JldHB3QG15LW15c3FsLWV4YW1wbGUtZXhvc2NhbGUtMTIzNC5haXZlbmNsb3VkLmNvbToyMTY5OS9kZWZhdWx0ZGI/c3NsLW1vZGU9UkVRVUlSRUQK <5>
-  MYSQL_USER: YXZuYWRtaW4= <6>
-  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkhleFZhbHVlcwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg== <7>
-----
-<1> Database name
-<2> Host to connect to
-<3> Password
-<4> Port
-<5> URL containing all necessary information to connect to the instance
-<6> Username
-<7> ca.crt to use when using `ssl-mode=VERIFY-CA`
-
-IMPORTANT: All data fields are Base64-encoded, like any other https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/[Kubernetes secret].
+include::appcat:ROOT:page$references/secrets.adoc[tag=mariadb]

--- a/docs/modules/ROOT/pages/exoscale-dbaas/opensearch/create.adoc
+++ b/docs/modules/ROOT/pages/exoscale-dbaas/opensearch/create.adoc
@@ -61,28 +61,7 @@ $ oc get secrets opensearch-creds -o yaml
 
 The output of the command above is a secret specification with the following structure:
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: opensearch-creds
-data:
-  OPENSEARCH_DASHBOARD_URI: aHR(...)0Mw== <1>
-  OPENSEARCH_HOST: ZXh(...)Y29t <2>
-  OPENSEARCH_PORT: Mj(...)k= <3>
-  OPENSEARCH_PASSWORD: QVZ(...)0pS <4>
-  OPENSEARCH_URI: aHR(..)ak5 <5>
-  OPENSEARCH_USER: YXZ(...)aW4= <6>
-----
-<1> Dashboard URL
-<2> Hostname
-<3> Port
-<4> Password
-<5> API URL
-<6> User
+include::appcat:ROOT:page$references/secrets.adoc[tag=opensearch]
 
 NOTE: Exoscale OpenSearch supports only connection via TLS.
 The certificates are signed by Let's Encrypt, so no ca.crt file required.
-
-IMPORTANT: All data fields are Base64-encoded, like any other https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/[Kubernetes secret].

--- a/docs/modules/ROOT/pages/exoscale-dbaas/postgresql/create.adoc
+++ b/docs/modules/ROOT/pages/exoscale-dbaas/postgresql/create.adoc
@@ -61,27 +61,4 @@ $ oc get secrets postgres-creds -o yaml
 
 The output of the command above is a secret specification with the following structure:
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-creds
-data:
-  POSTGRESQL_DB: ZGVmYXVsdGRi <1>
-  POSTGRESQL_HOST: bXktcG9zdGdyZXMtZXhhbXBsZS1leG9zY2FsZS0xMjM0LmFpdmVuY2xvdWQuY29tCg== <2>
-  POSTGRESQL_PASSWORD: QVZOU19zb21lc3VwZXJzZWNyZXRwdwo= <3>
-  POSTGRESQL_PORT: MjE2OTk= <4>
-  POSTGRESQL_URL: cG9zdGdyZXM6Ly9hdm5hZG1pbjpBVk5TX3NvbWVzdXBlcnNlY3JldHB3QG15LXBvc3RncmVzLWV4YW1wbGUtZXhvc2NhbGUtMTIzNC5haXZlbmNsb3VkLmNvbToyMTY5OS9kZWZhdWx0ZGI/c3NsbW9kZT1yZXF1aXJlCg== <5>
-  POSTGRESQL_USER: YXZuYWRtaW4= <6>
-  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCkhleFZhbHVlcwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg== <7>
-----
-<1> Database name
-<2> Host to connect to
-<3> Password
-<4> Port
-<5> URL containing all necessary information to connect to the instance
-<6> Username
-<7> ca.crt to use when using `sslmode=verify-full`
-
-IMPORTANT: All data fields are Base64-encoded, like any other https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/[Kubernetes secret].
+include::appcat:ROOT:page$references/secrets.adoc[tag=postgres]

--- a/docs/modules/ROOT/pages/exoscale-dbaas/redis/create.adoc
+++ b/docs/modules/ROOT/pages/exoscale-dbaas/redis/create.adoc
@@ -56,26 +56,7 @@ $ oc get secrets redis-creds -o yaml
 
 The output of the command above is a secret specification with the following structure:
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: redis-creds
-data:
-  REDIS_HOST: MTI3LjAuMC4xCg== <1>
-  REDIS_PASSWORD: QVZOU19zb21lc3VwZXJzZWNyZXRwdwo= <2>
-  REDIS_PORT: MjE3MDA= <3>
-  REDIS_URL: cmVkaXNzOi8vZGVmYXVsdDpBVk5TX3NvbWVzdXBlcnNlY3JldHB3QDEyNy4wLjAuMToyMTcwMAo= <4>
-  REDIS_USERNAME: ZGVmYXVsdA== <5>
-----
-<1> Host to connect to
-<2> Password
-<3> Port to use
-<4> URL containing all necessary information to connect to the instance
-<5> Username
+include::appcat:ROOT:page$references/secrets.adoc[tag=redis]
 
 NOTE: Exoscale Redis supports connection via TLS.
 The certificates are signed by Let's Encrypt, so no ca.crt file required.
-
-IMPORTANT: All data fields are Base64-encoded, like any other https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/[Kubernetes secret].

--- a/docs/modules/ROOT/pages/references/crds.adoc
+++ b/docs/modules/ROOT/pages/references/crds.adoc
@@ -8,8 +8,6 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 .Packages
 - xref:{anchor_prefix}-appcat-vshn-io-v1[$$appcat.vshn.io/v1$$]
-- xref:{anchor_prefix}-exoscale-appcat-vshn-io-v1[$$exoscale.appcat.vshn.io/v1$$]
-- xref:{anchor_prefix}-vshn-appcat-vshn-io-v1[$$vshn.appcat.vshn.io/v1$$]
 
 
 [id="{anchor_prefix}-appcat-vshn-io-v1"]
@@ -22,19 +20,12 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-condition"]
-=== Condition
+=== Condition 
 
 
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkastatus[$$ExoscaleKafkaStatus$$]
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlstatus[$$ExoscaleMySQLStatus$$]
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchstatus[$$ExoscaleOpenSearchStatus$$]
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlstatus[$$ExoscalePostgreSQLStatus$$]
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisstatus[$$ExoscaleRedisStatus$$]
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketstatus[$$ObjectBucketStatus$$]
-- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlstatus[$$VSHNPostgreSQLStatus$$]
 - xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketstatus[$$ObjectBucketStatus$$]
 ****
 
@@ -50,7 +41,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucket"]
-=== ObjectBucket
+=== ObjectBucket 
 
 ObjectBucket is the API for creating S3 buckets.
 
@@ -63,12 +54,12 @@ ObjectBucket is the API for creating S3 buckets.
 | *`kind`* __string__ | `ObjectBucket`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketspec[$$ObjectBucketSpec$$]__ |
+| *`spec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketspec[$$ObjectBucketSpec$$]__ | 
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketparameters"]
-=== ObjectBucketParameters
+=== ObjectBucketParameters 
 
 ObjectBucketParameters are the configurable fields of a ObjectBucket.
 
@@ -86,7 +77,7 @@ ObjectBucketParameters are the configurable fields of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketspec"]
-=== ObjectBucketSpec
+=== ObjectBucketSpec 
 
 ObjectBucketSpec defines the desired state of a ObjectBucket.
 
@@ -98,7 +89,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`parameters`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketparameters[$$ObjectBucketParameters$$]__ |
+| *`parameters`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketparameters[$$ObjectBucketParameters$$]__ | 
 |===
 
 
@@ -130,7 +121,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasbackupspec"]
-=== ExoscaleDBaaSBackupSpec
+=== ExoscaleDBaaSBackupSpec 
 
 
 
@@ -149,7 +140,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasmaintenanceschedulespec"]
-=== ExoscaleDBaaSMaintenanceScheduleSpec
+=== ExoscaleDBaaSMaintenanceScheduleSpec 
 
 
 
@@ -171,7 +162,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasnetworkspec"]
-=== ExoscaleDBaaSNetworkSpec
+=== ExoscaleDBaaSNetworkSpec 
 
 
 
@@ -192,7 +183,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec"]
-=== ExoscaleDBaaSServiceSpec
+=== ExoscaleDBaaSServiceSpec 
 
 
 
@@ -213,7 +204,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaassizespec"]
-=== ExoscaleDBaaSSizeSpec
+=== ExoscaleDBaaSSizeSpec 
 
 
 
@@ -233,7 +224,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafka"]
-=== ExoscaleKafka
+=== ExoscaleKafka 
 
 ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
@@ -251,7 +242,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkadbaassizespec"]
-=== ExoscaleKafkaDBaaSSizeSpec
+=== ExoscaleKafkaDBaaSSizeSpec 
 
 
 
@@ -268,7 +259,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkaparameters"]
-=== ExoscaleKafkaParameters
+=== ExoscaleKafkaParameters 
 
 
 
@@ -288,7 +279,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkaservicespec"]
-=== ExoscaleKafkaServiceSpec
+=== ExoscaleKafkaServiceSpec 
 
 
 
@@ -300,14 +291,14 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
 | *`kafkaSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | KafkaSettings contains additional Kafka settings.
 | *`version`* __string__ | Version contains the minor version for Kafka. Currently only "3.2" is supported. Leave it empty to always get the latest supported version.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkaspec"]
-=== ExoscaleKafkaSpec
+=== ExoscaleKafkaSpec 
 
 
 
@@ -326,7 +317,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysql"]
-=== ExoscaleMySQL
+=== ExoscaleMySQL 
 
 ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
@@ -344,7 +335,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlparameters"]
-=== ExoscaleMySQLParameters
+=== ExoscaleMySQLParameters 
 
 
 
@@ -365,7 +356,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlservicespec"]
-=== ExoscaleMySQLServiceSpec
+=== ExoscaleMySQLServiceSpec 
 
 
 
@@ -377,14 +368,14 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
 | *`majorVersion`* __string__ | MajorVersion contains the major version for MySQL. Currently only "8" is supported. Leave it empty to always get the latest supported version.
 | *`mysqlSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | MySQLSettings contains additional MySQL settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlspec"]
-=== ExoscaleMySQLSpec
+=== ExoscaleMySQLSpec 
 
 
 
@@ -405,7 +396,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchparameters"]
-=== ExoscaleOpenSearchParameters
+=== ExoscaleOpenSearchParameters 
 
 
 
@@ -426,7 +417,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchservicespec"]
-=== ExoscaleOpenSearchServiceSpec
+=== ExoscaleOpenSearchServiceSpec 
 
 
 
@@ -440,14 +431,14 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 | Field | Description
 | *`apiVersion`* __string__ | `exoscale.appcat.vshn.io/v1`
 | *`kind`* __string__ | `ExoscaleOpenSearchServiceSpec`
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
 | *`majorVersion`* __string__ | MajorVersion contains the version for OpenSearch. Currently only "2" and "1" is supported. Leave it empty to always get the latest supported version.
 | *`opensearchSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | OpenSearchSettings contains additional OpenSearch settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchspec"]
-=== ExoscaleOpenSearchSpec
+=== ExoscaleOpenSearchSpec 
 
 
 
@@ -466,7 +457,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresql"]
-=== ExoscalePostgreSQL
+=== ExoscalePostgreSQL 
 
 ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
@@ -484,7 +475,7 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlparameters"]
-=== ExoscalePostgreSQLParameters
+=== ExoscalePostgreSQLParameters 
 
 
 
@@ -505,7 +496,7 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlservicespec"]
-=== ExoscalePostgreSQLServiceSpec
+=== ExoscalePostgreSQLServiceSpec 
 
 
 
@@ -517,14 +508,14 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
 | *`majorVersion`* __string__ | MajorVersion contains the major version for PostgreSQL. Currently only "14" is supported. Leave it empty to always get the latest supported version.
 | *`pgSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | PGSettings contains additional PostgreSQL settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlspec"]
-=== ExoscalePostgreSQLSpec
+=== ExoscalePostgreSQLSpec 
 
 
 
@@ -543,7 +534,7 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredis"]
-=== ExoscaleRedis
+=== ExoscaleRedis 
 
 ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
@@ -561,7 +552,7 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisparameters"]
-=== ExoscaleRedisParameters
+=== ExoscaleRedisParameters 
 
 
 
@@ -581,7 +572,7 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisservicespec"]
-=== ExoscaleRedisServiceSpec
+=== ExoscaleRedisServiceSpec 
 
 
 
@@ -593,13 +584,13 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
 | *`redisSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | RedisSettings contains additional Redis settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisspec"]
-=== ExoscaleRedisSpec
+=== ExoscaleRedisSpec 
 
 
 
@@ -639,7 +630,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaasbackupspec"]
-=== VSHNDBaaSBackupSpec
+=== VSHNDBaaSBackupSpec 
 
 VSHNDBaaSBackupSpec contains settings to control the backups of an instance.
 
@@ -656,7 +647,7 @@ VSHNDBaaSBackupSpec contains settings to control the backups of an instance.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaasmaintenanceschedulespec"]
-=== VSHNDBaaSMaintenanceScheduleSpec
+=== VSHNDBaaSMaintenanceScheduleSpec 
 
 VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of an instance.
 
@@ -674,7 +665,7 @@ VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaasnetworkspec"]
-=== VSHNDBaaSNetworkSpec
+=== VSHNDBaaSNetworkSpec 
 
 VSHNDBaaSNetworkSpec contains any network related settings.
 
@@ -691,7 +682,7 @@ VSHNDBaaSNetworkSpec contains any network related settings.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaassizespec"]
-=== VSHNDBaaSSizeSpec
+=== VSHNDBaaSSizeSpec 
 
 VSHNDBaaSSizeSpec contains settings to control the sizing of a service.
 
@@ -710,7 +701,7 @@ VSHNDBaaSSizeSpec contains settings to control the sizing of a service.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresql"]
-=== VSHNPostgreSQL
+=== VSHNPostgreSQL 
 
 VSHNPostgreSQL is the API for creating Postgresql clusters.
 
@@ -728,7 +719,7 @@ VSHNPostgreSQL is the API for creating Postgresql clusters.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlparameters"]
-=== VSHNPostgreSQLParameters
+=== VSHNPostgreSQLParameters 
 
 VSHNPostgreSQLParameters are the configurable fields of a VSHNPostgreSQL.
 
@@ -749,7 +740,7 @@ VSHNPostgreSQLParameters are the configurable fields of a VSHNPostgreSQL.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlservicespec"]
-=== VSHNPostgreSQLServiceSpec
+=== VSHNPostgreSQLServiceSpec 
 
 VSHNPostgreSQLServiceSpec contains PostgreSQL DBaaS specific properties
 
@@ -767,7 +758,7 @@ VSHNPostgreSQLServiceSpec contains PostgreSQL DBaaS specific properties
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlspec"]
-=== VSHNPostgreSQLSpec
+=== VSHNPostgreSQLSpec 
 
 VSHNPostgreSQLSpec defines the desired state of a VSHNPostgreSQL.
 

--- a/docs/modules/ROOT/pages/references/crds.adoc
+++ b/docs/modules/ROOT/pages/references/crds.adoc
@@ -22,7 +22,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-condition"]
-=== Condition 
+=== Condition
 
 
 
@@ -35,6 +35,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 - xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisstatus[$$ExoscaleRedisStatus$$]
 - xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketstatus[$$ObjectBucketStatus$$]
 - xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlstatus[$$VSHNPostgreSQLStatus$$]
+- xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketstatus[$$ObjectBucketStatus$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -49,7 +50,7 @@ This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucket"]
-=== ObjectBucket 
+=== ObjectBucket
 
 ObjectBucket is the API for creating S3 buckets.
 
@@ -62,12 +63,12 @@ ObjectBucket is the API for creating S3 buckets.
 | *`kind`* __string__ | `ObjectBucket`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketspec[$$ObjectBucketSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketspec[$$ObjectBucketSpec$$]__ |
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketparameters"]
-=== ObjectBucketParameters 
+=== ObjectBucketParameters
 
 ObjectBucketParameters are the configurable fields of a ObjectBucket.
 
@@ -85,7 +86,7 @@ ObjectBucketParameters are the configurable fields of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketspec"]
-=== ObjectBucketSpec 
+=== ObjectBucketSpec
 
 ObjectBucketSpec defines the desired state of a ObjectBucket.
 
@@ -97,11 +98,22 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`parameters`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketparameters[$$ObjectBucketParameters$$]__ | 
+| *`parameters`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-v1-objectbucketparameters[$$ObjectBucketParameters$$]__ |
 |===
 
 
 
+
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="api-reference"]
+== Exoscale Reference
+
+This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
+
+.Packages
+- xref:{anchor_prefix}-exoscale-appcat-vshn-io-v1[$$exoscale.appcat.vshn.io/v1$$]
 
 
 [id="{anchor_prefix}-exoscale-appcat-vshn-io-v1"]
@@ -118,7 +130,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasbackupspec"]
-=== ExoscaleDBaaSBackupSpec 
+=== ExoscaleDBaaSBackupSpec
 
 
 
@@ -137,7 +149,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasmaintenanceschedulespec"]
-=== ExoscaleDBaaSMaintenanceScheduleSpec 
+=== ExoscaleDBaaSMaintenanceScheduleSpec
 
 
 
@@ -159,7 +171,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasnetworkspec"]
-=== ExoscaleDBaaSNetworkSpec 
+=== ExoscaleDBaaSNetworkSpec
 
 
 
@@ -180,7 +192,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec"]
-=== ExoscaleDBaaSServiceSpec 
+=== ExoscaleDBaaSServiceSpec
 
 
 
@@ -201,7 +213,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaassizespec"]
-=== ExoscaleDBaaSSizeSpec 
+=== ExoscaleDBaaSSizeSpec
 
 
 
@@ -221,7 +233,7 @@ ObjectBucketSpec defines the desired state of a ObjectBucket.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafka"]
-=== ExoscaleKafka 
+=== ExoscaleKafka
 
 ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
@@ -239,7 +251,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkadbaassizespec"]
-=== ExoscaleKafkaDBaaSSizeSpec 
+=== ExoscaleKafkaDBaaSSizeSpec
 
 
 
@@ -256,7 +268,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkaparameters"]
-=== ExoscaleKafkaParameters 
+=== ExoscaleKafkaParameters
 
 
 
@@ -276,7 +288,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkaservicespec"]
-=== ExoscaleKafkaServiceSpec 
+=== ExoscaleKafkaServiceSpec
 
 
 
@@ -288,14 +300,14 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
 | *`kafkaSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | KafkaSettings contains additional Kafka settings.
 | *`version`* __string__ | Version contains the minor version for Kafka. Currently only "3.2" is supported. Leave it empty to always get the latest supported version.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalekafkaspec"]
-=== ExoscaleKafkaSpec 
+=== ExoscaleKafkaSpec
 
 
 
@@ -314,7 +326,7 @@ ExoscaleKafka is the API for creating Kafka instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysql"]
-=== ExoscaleMySQL 
+=== ExoscaleMySQL
 
 ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
@@ -332,7 +344,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlparameters"]
-=== ExoscaleMySQLParameters 
+=== ExoscaleMySQLParameters
 
 
 
@@ -353,7 +365,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlservicespec"]
-=== ExoscaleMySQLServiceSpec 
+=== ExoscaleMySQLServiceSpec
 
 
 
@@ -365,14 +377,14 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
 | *`majorVersion`* __string__ | MajorVersion contains the major version for MySQL. Currently only "8" is supported. Leave it empty to always get the latest supported version.
 | *`mysqlSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | MySQLSettings contains additional MySQL settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalemysqlspec"]
-=== ExoscaleMySQLSpec 
+=== ExoscaleMySQLSpec
 
 
 
@@ -393,7 +405,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchparameters"]
-=== ExoscaleOpenSearchParameters 
+=== ExoscaleOpenSearchParameters
 
 
 
@@ -414,7 +426,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchservicespec"]
-=== ExoscaleOpenSearchServiceSpec 
+=== ExoscaleOpenSearchServiceSpec
 
 
 
@@ -428,14 +440,14 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 | Field | Description
 | *`apiVersion`* __string__ | `exoscale.appcat.vshn.io/v1`
 | *`kind`* __string__ | `ExoscaleOpenSearchServiceSpec`
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
 | *`majorVersion`* __string__ | MajorVersion contains the version for OpenSearch. Currently only "2" and "1" is supported. Leave it empty to always get the latest supported version.
 | *`opensearchSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | OpenSearchSettings contains additional OpenSearch settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleopensearchspec"]
-=== ExoscaleOpenSearchSpec 
+=== ExoscaleOpenSearchSpec
 
 
 
@@ -454,7 +466,7 @@ ExoscaleMySQL is the API for creating MySQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresql"]
-=== ExoscalePostgreSQL 
+=== ExoscalePostgreSQL
 
 ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
@@ -472,7 +484,7 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlparameters"]
-=== ExoscalePostgreSQLParameters 
+=== ExoscalePostgreSQLParameters
 
 
 
@@ -493,7 +505,7 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlservicespec"]
-=== ExoscalePostgreSQLServiceSpec 
+=== ExoscalePostgreSQLServiceSpec
 
 
 
@@ -505,14 +517,14 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
 | *`majorVersion`* __string__ | MajorVersion contains the major version for PostgreSQL. Currently only "14" is supported. Leave it empty to always get the latest supported version.
 | *`pgSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | PGSettings contains additional PostgreSQL settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscalepostgresqlspec"]
-=== ExoscalePostgreSQLSpec 
+=== ExoscalePostgreSQLSpec
 
 
 
@@ -531,7 +543,7 @@ ExoscalePostgreSQL is the API for creating PostgreSQL on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredis"]
-=== ExoscaleRedis 
+=== ExoscaleRedis
 
 ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
@@ -549,7 +561,7 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisparameters"]
-=== ExoscaleRedisParameters 
+=== ExoscaleRedisParameters
 
 
 
@@ -569,7 +581,7 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisservicespec"]
-=== ExoscaleRedisServiceSpec 
+=== ExoscaleRedisServiceSpec
 
 
 
@@ -581,13 +593,13 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ | 
+| *`ExoscaleDBaaSServiceSpec`* __xref:{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaledbaasservicespec[$$ExoscaleDBaaSServiceSpec$$]__ |
 | *`redisSettings`* __xref:{anchor_prefix}-k8s-io-apimachinery-pkg-runtime-rawextension[$$RawExtension$$]__ | RedisSettings contains additional Redis settings.
 |===
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-exoscale-v1-exoscaleredisspec"]
-=== ExoscaleRedisSpec 
+=== ExoscaleRedisSpec
 
 
 
@@ -605,6 +617,17 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
 
 
+// Generated documentation. Please do not edit.
+:anchor_prefix: k8s-api
+
+[id="api-reference"]
+== VSHN Reference
+
+This is a https://github.com/elastic/crd-ref-docs[generated] API documentation.
+
+.Packages
+- xref:{anchor_prefix}-vshn-appcat-vshn-io-v1[$$vshn.appcat.vshn.io/v1$$]
+
 
 [id="{anchor_prefix}-vshn-appcat-vshn-io-v1"]
 == vshn.appcat.vshn.io/v1
@@ -616,7 +639,7 @@ ExoscaleRedis is the API for creating Redis instances on Exoscale.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaasbackupspec"]
-=== VSHNDBaaSBackupSpec 
+=== VSHNDBaaSBackupSpec
 
 VSHNDBaaSBackupSpec contains settings to control the backups of an instance.
 
@@ -633,7 +656,7 @@ VSHNDBaaSBackupSpec contains settings to control the backups of an instance.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaasmaintenanceschedulespec"]
-=== VSHNDBaaSMaintenanceScheduleSpec 
+=== VSHNDBaaSMaintenanceScheduleSpec
 
 VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of an instance.
 
@@ -651,7 +674,7 @@ VSHNDBaaSMaintenanceScheduleSpec contains settings to control the maintenance of
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaasnetworkspec"]
-=== VSHNDBaaSNetworkSpec 
+=== VSHNDBaaSNetworkSpec
 
 VSHNDBaaSNetworkSpec contains any network related settings.
 
@@ -668,7 +691,7 @@ VSHNDBaaSNetworkSpec contains any network related settings.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshndbaassizespec"]
-=== VSHNDBaaSSizeSpec 
+=== VSHNDBaaSSizeSpec
 
 VSHNDBaaSSizeSpec contains settings to control the sizing of a service.
 
@@ -687,7 +710,7 @@ VSHNDBaaSSizeSpec contains settings to control the sizing of a service.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresql"]
-=== VSHNPostgreSQL 
+=== VSHNPostgreSQL
 
 VSHNPostgreSQL is the API for creating Postgresql clusters.
 
@@ -705,7 +728,7 @@ VSHNPostgreSQL is the API for creating Postgresql clusters.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlparameters"]
-=== VSHNPostgreSQLParameters 
+=== VSHNPostgreSQLParameters
 
 VSHNPostgreSQLParameters are the configurable fields of a VSHNPostgreSQL.
 
@@ -726,7 +749,7 @@ VSHNPostgreSQLParameters are the configurable fields of a VSHNPostgreSQL.
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlservicespec"]
-=== VSHNPostgreSQLServiceSpec 
+=== VSHNPostgreSQLServiceSpec
 
 VSHNPostgreSQLServiceSpec contains PostgreSQL DBaaS specific properties
 
@@ -744,7 +767,7 @@ VSHNPostgreSQLServiceSpec contains PostgreSQL DBaaS specific properties
 
 
 [id="{anchor_prefix}-github-com-vshn-component-appcat-apis-vshn-v1-vshnpostgresqlspec"]
-=== VSHNPostgreSQLSpec 
+=== VSHNPostgreSQLSpec
 
 VSHNPostgreSQLSpec defines the desired state of a VSHNPostgreSQL.
 

--- a/docs/modules/ROOT/pages/references/secrets.adoc
+++ b/docs/modules/ROOT/pages/references/secrets.adoc
@@ -1,0 +1,163 @@
+= Secret References
+
+To ensure maximum compatibility between the various service providers, we ensure that the secrets are as consistent as possible within a given service type.
+Due to differences between service providers it might be possible that the access secrets aren't 100% interchangeable.
+
+== PostgreSQL
+
+The example secrets on this page contains the plaintext values for the given keys.
+
+// tag::postgres[]
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+stringData:
+  POSTGRESQL_DB: postgres <1>
+  POSTGRESQL_HOST: my-postgres-example.my-cloud.com <2>
+  POSTGRESQL_PASSWORD: my-secret <3>
+  POSTGRESQL_PORT: 21699 <4>
+  POSTGRESQL_URL: postgres://postgres:my-secret@my-postgres-example.my-cloud.com:21699/postgresql?sslmode=require <5>
+  POSTGRESQL_USER: postgres <6>
+  ca.crt: | <7>
+    -----BEGIN CERTIFICATE-----
+    HexValues
+    -----END CERTIFICATE-----
+----
+<1> Database name
+<2> Host to connect to
+<3> Password
+<4> Port
+<5> URL containing all necessary information to connect to the instance
+<6> Username
+<7> ca.crt to use when using `sslmode=verify-full`
+
+// end::postgres[]
+
+== MySQL
+
+The example secrets on this page contains the plaintext values for the given keys.
+// tag::mariadb[]
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-creds
+stringData:
+  MYSQL_DB: defaultdb <1>
+  MYSQL_HOST: my-mysql.my-cloud.com <2>
+  MYSQL_PASSWORD: my-secret <3>
+  MYSQL_PORT: 21699 <4>
+  MYSQL_URL: mysql://superuser:my-secret@my-mysql.my-cloud.com:21699/defaultdb?ssl-mode=REQUIRED <5>
+  MYSQL_USER: superuser <6>
+  ca.crt: | <7>
+    -----BEGIN CERTIFICATE-----
+    HexValues
+    -----END CERTIFICATE-----
+----
+<1> Database name
+<2> Host to connect to
+<3> Password
+<4> Port
+<5> URL containing all necessary information to connect to the instance
+<6> Username
+<7> ca.crt to use when using `ssl-mode=VERIFY-CA`
+
+// end::mariadb[]
+
+== Redis
+
+The example secrets on this page contains the plaintext values for the given keys.
+
+// tag::redis[]
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-creds
+stringData:
+  REDIS_HOST: 127.0.0.1 <1>
+  REDIS_PASSWORD: my-secret <2>
+  REDIS_PORT: 21700 <3>
+  REDIS_URL: rediss://default:my-secret@127.0.0.1:21700
+ <4>
+  REDIS_USERNAME: default <5>
+----
+<1> Host to connect to
+<2> Password
+<3> Port to use
+<4> URL containing all necessary information to connect to the instance
+<5> Username
+
+// end::redis[]
+
+== OpenSearch
+
+The example secrets on this page contains the plaintext values for the given keys.
+
+// tag::opensearch[]
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: opensearch-creds
+stringData:
+  OPENSEARCH_DASHBOARD_URI: https://my-example-opensearch.my-cloud.com:443 <1>
+  OPENSEARCH_HOST: my-example-opensearch.my-cloud.com <2>
+  OPENSEARCH_PORT: 21699 <3>
+  OPENSEARCH_PASSWORD: my-secret <4>
+  OPENSEARCH_URI: https://superuser:my-secret@my-example-opensearch.my-cloud.com:21699 <5>
+  OPENSEARCH_USER: superuser <6>
+----
+<1> Dashboard URL
+<2> Hostname
+<3> Port
+<4> Password
+<5> API URL
+<6> User
+
+// end::opensearch[]
+
+== Kafka
+
+The example secrets on this page contains the plaintext values for the given keys.
+
+// tag::kafka[]
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-creds
+stringData:
+  KAFKA_HOST: my-kafka.my-cloud.com <1>
+  KAFKA_NODES: 127.0.0.1:21701 127.0.0.2:21701 127.0.0.3:21701 <2>
+  KAFKA_PORT: 21701<3>
+  KAFKA_URI: my-kafka.my-cloud.com:21701 <4>
+  ca.crt: | <5>
+    -----BEGIN CERTIFICATE-----
+    HexValues
+    -----END CERTIFICATE-----
+  service.cert: | <6>
+    -----BEGIN CERTIFICATE-----
+    HexValues
+    -----END CERTIFICATE-----
+  service.key: | <7>
+    -----BEGIN CERTIFICATE-----
+    HexValues
+    -----END CERTIFICATE-----
+----
+<1> Hostname for the Kafka instance
+<2> List of Kafka Node IPs
+<3> Port the Kafka instance listens on
+<4> Full URI including port number
+<5> Certificate Authority to verify the Kafka instance certificate
+<6> Client certificate to authenticate to the instance
+<6> Client key to authenticate to the instance
+
+// end::kafka[]

--- a/docs/modules/ROOT/pages/vshn-managed/postgresql/create.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/postgresql/create.adoc
@@ -19,7 +19,7 @@ metadata:
 spec:
   parameters:
     service:
-      majorVersion: 15 <3>
+      majorVersion: "15" <3>
       pgSettings:
         timezone: Europe/Zurich <4>
     size: <5>

--- a/docs/modules/ROOT/pages/vshn-managed/postgresql/create.adoc
+++ b/docs/modules/ROOT/pages/vshn-managed/postgresql/create.adoc
@@ -58,25 +58,4 @@ $ oc get secrets postgres-creds -o yaml
 
 The output of the command above is a secret specification with the following structure:
 
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgres-creds
-data:
-  POSTGRESQL_DB: ZGVmYXVsdGRi <1>
-  POSTGRESQL_HOST: bXktcG9zdGdyZXMtZXhhbXBsZS1leG9zY2FsZS0xMjM0LmFpdmVuY2xvdWQuY29tCg== <2>
-  POSTGRESQL_PASSWORD: QVZOU19zb21lc3VwZXJzZWNyZXRwdwo= <3>
-  POSTGRESQL_PORT: MjE2OTk= <4>
-  POSTGRESQL_URL: cG9zdGdyZXM6Ly9hdm5hZG1pbjpBVk5TX3NvbWVzdXBlcnNlY3JldHB3QG15LXBvc3RncmVzLWV4YW1wbGUtZXhvc2NhbGUtMTIzNC5haXZlbmNsb3VkLmNvbToyMTY5OS9kZWZhdWx0ZGI/c3NsbW9kZT1yZXF1aXJlCg== <5>
-  POSTGRESQL_USER: YXZuYWRtaW4= <6>
-----
-<1> Database name
-<2> Host to connect to
-<3> Password
-<4> Port
-<5> URL containing all necessary information to connect to the instance
-<6> Username
-
-IMPORTANT: All data fields are Base64-encoded, like any other https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/[Kubernetes secret].
+include::appcat:ROOT:page$references/secrets.adoc[tag=postgres]


### PR DESCRIPTION
The goal is to have the same secrets for each provider for a given
service. Because of that it makes sense to have a dedicated secrets page
where each secret can be referenced where needed.

Also the values have been base64 decoded, so that it's clear how they will look like.